### PR TITLE
Allow passing a custom docs root

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ You can customize the dropdown appearance by overriding these CSS classes in you
 
 3. **Check browser console**: Look for any errors that might indicate component loading issues.
 
-4. **Verify path configuration**: The default path is `/docs/`. If your docs use a different path (e.g., `/documentation/`), you may need to swizzle the component and customize it.
+4. **Verify path configuration**: The default path is `/docs/`. If your docs use a different path (e.g., `/documentation/`), set the `docsRoot` option in your plugin config (see [Advanced Configuration](#custom-docs-root-path)).
 
 5. **Check DOM structure**: Open DevTools and run:
    ```javascript
@@ -369,17 +369,29 @@ You can customize the dropdown appearance by overriding these CSS classes in you
 
 ## Advanced Configuration
 
-### Custom Paths and Blog Support
+### Custom Docs Root Path
 
-The plugin currently supports the default `/docs/` path out of the box.
+By default, the plugin targets the `/docs/` path. If your Docusaurus site uses a custom `routeBasePath` for the docs plugin, you can configure the root path with the `docsRoot` option:
 
-For blog support or custom paths, you can swizzle the components if needed:
+```javascript
+module.exports = {
+  plugins: [
+    ['docusaurus-markdown-source-plugin', { docsRoot: '/documentation' }],
+  ],
+};
+```
+
+The option accepts flexible input (`docs`, `/docs`, `/docs/` all normalize to `/docs`). If omitted, it defaults to `/docs`.
+
+### Blog Support
+
+For blog support or other advanced customization, you can swizzle the components:
 
 ```bash
 npm run swizzle docusaurus-markdown-source-plugin Root -- --eject
 ```
 
-**Note:** Swizzling means you'll manually maintain these files and won't receive automatic updates. Native configuration support for custom paths is planned for a future release.
+**Note:** Swizzling means you'll manually maintain these files and won't receive automatic updates.
 
 ## Contributing
 

--- a/components/MarkdownActionsDropdown/index.js
+++ b/components/MarkdownActionsDropdown/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 
-export default function MarkdownActionsDropdown() {
+export default function MarkdownActionsDropdown({ docsRoot = '/docs' }) {
   const [copied, setCopied] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
@@ -9,7 +9,7 @@ export default function MarkdownActionsDropdown() {
   const currentPath = typeof window !== 'undefined' ? window.location.pathname : '';
 
   // Only show on docs pages (not blog, homepage, etc.)
-  const isDocsPage = currentPath.startsWith('/docs/');
+  const isDocsPage = currentPath.startsWith(docsRoot + '/');
 
   // Handle click outside to close dropdown
   useEffect(() => {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function convertDetailsToMarkdown(content) {
 }
 
 // Clean markdown content for raw display - remove MDX/Docusaurus-specific syntax
-function cleanMarkdownForDisplay(content, filepath) {
+function cleanMarkdownForDisplay(content, filepath, docsRoot) {
   // Get the directory path for this file (relative to docs root)
   const fileDir = filepath.replace(/[^/]*$/, ''); // Remove filename, keep directory
 
@@ -98,13 +98,13 @@ function cleanMarkdownForDisplay(content, filepath) {
   // This runs AFTER Tabs/details conversion to preserve their content
   content = content.replace(/<[A-Z][a-zA-Z]*[\s\S]*?(?:\/>|<\/[A-Z][a-zA-Z]*>)/g, '');
 
-  // 10. Convert relative image paths to absolute paths from /docs/ root (Claude style)
+  // 10. Convert relative image paths to absolute paths from docs root (Claude style)
   // Matches: ![alt](./img/file.png) or ![alt](img/file.png)
   content = content.replace(
     /!\[([^\]]*)\]\((\.\/)?img\/([^)]+)\)/g,
     (match, alt, relPrefix, filename) => {
       // Convert to absolute path: /docs/path/to/file/img/filename
-      return `![${alt}](/docs/${fileDir}img/${filename})`;
+      return `![${alt}](${docsRoot}/${fileDir}img/${filename})`;
     }
   );
 
@@ -181,12 +181,24 @@ async function copyImageDirectories(docsDir, buildDir) {
 }
 
 module.exports = function markdownSourcePlugin(context, options) {
+  // Normalize docsRoot: ensure leading slash, no trailing slash
+  let docsRoot = (options.docsRoot || '/docs').replace(/\/+$/, '');
+  if (!docsRoot.startsWith('/')) {
+    docsRoot = '/' + docsRoot;
+  }
+
   return {
     name: 'markdown-source-plugin',
 
     // Provide theme components from the plugin (eliminates need for manual copying)
     getThemePath() {
       return path.resolve(__dirname, './theme');
+    },
+
+    // Expose docsRoot to theme components via global data
+    async contentLoaded({ actions }) {
+      const { setGlobalData } = actions;
+      setGlobalData({ docsRoot });
     },
 
     async postBuild({ outDir }) {
@@ -213,7 +225,7 @@ module.exports = function markdownSourcePlugin(context, options) {
           const content = await fs.readFile(sourcePath, 'utf8');
 
           // Clean markdown for raw display
-          const cleanedContent = cleanMarkdownForDisplay(content, mdFile);
+          const cleanedContent = cleanMarkdownForDisplay(content, mdFile, docsRoot);
 
           // Write the cleaned content
           await fs.writeFile(destPath, cleanedContent, 'utf8');

--- a/theme/Root.js
+++ b/theme/Root.js
@@ -1,11 +1,13 @@
 // theme/Root.js - Plugin-provided theme component
 import React, { useEffect } from 'react';
 import { useLocation } from '@docusaurus/router';
+import { usePluginData } from '@docusaurus/useGlobalData';
 import { createRoot } from 'react-dom/client';
 import MarkdownActionsDropdown from '../components/MarkdownActionsDropdown';
 
 export default function Root({ children }) {
   const { hash, pathname } = useLocation();
+  const { docsRoot } = usePluginData('markdown-source-plugin');
 
   useEffect(() => {
     if (hash) {
@@ -40,7 +42,7 @@ export default function Root({ children }) {
   useEffect(() => {
     const injectDropdown = () => {
       // Only inject on docs pages
-      if (!pathname.startsWith('/docs/')) return;
+      if (!pathname.startsWith(docsRoot + '/')) return;
 
       const articleHeader = document.querySelector('article .markdown header');
       if (!articleHeader) return;
@@ -57,7 +59,7 @@ export default function Root({ children }) {
 
       // Render React component into container
       const root = createRoot(container);
-      root.render(<MarkdownActionsDropdown />);
+      root.render(<MarkdownActionsDropdown docsRoot={docsRoot} />);
     };
 
     // Try to inject after a short delay to ensure DOM is ready


### PR DESCRIPTION
Make the plugin not hardcode to `/docs` for better flexibility

I copied-pasted the plugin and edited but think this addition would be more robuse