### PR TITLE
support react19

### DIFF
--- a/components/MarkdownActionsDropdown/index.js
+++ b/components/MarkdownActionsDropdown/index.js
@@ -4,9 +4,14 @@ export default function MarkdownActionsDropdown() {
   const [copied, setCopied] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
+  // Pathname must be read only after mount to avoid SSR/client hydration mismatch (React 19)
+  const [currentPath, setCurrentPath] = useState('');
 
-  // Get pathname from window.location
-  const currentPath = typeof window !== 'undefined' ? window.location.pathname : '';
+  useEffect(() => {
+    setCurrentPath(typeof window !== 'undefined' ? window.location.pathname : '');
+  }, []);
+
+
 
   // Only show on docs pages (not blog, homepage, etc.)
   const isDocsPage = currentPath.startsWith('/docs/');

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "homepage": "https://github.com/FlyNumber/markdown_docusaurus_plugin#readme",
   "peerDependencies": {
     "@docusaurus/core": "^3.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "fs-extra": "^11.0.0"


### PR DESCRIPTION
### Summary
This PR adds support for React 19 while keeping compatibility with React 18.
fixed: 
- https://github.com/FlyNumber/markdown_docusaurus_plugin/issues/1
### Changes

- **peerDependencies** (`package.json`): Allow both React 18 and 19:
  - `react`: `^18.0.0 || ^19.0.0`
  - `react-dom`: `^18.0.0 || ^19.0.0`

- **MarkdownActionsDropdown** (`components/MarkdownActionsDropdown/index.js`): Make pathname usage hydration-safe for React 19:
  - Pathname is no longer read during initial render (which could differ between server and client).
  - It is now set in `useEffect` after mount using `window.location.pathname`, so server and client render the same initial output and React 19’s stricter hydration checks pass.

### Backward compatibility
- React 18 is still supported via the same peer range (`^18.0.0 || ^19.0.0`).
- No breaking API or behavior changes; the dropdown still only appears on `/docs/` pages after the client has the pathname.

### Testing
- [x] Verified that the dropdown works as before and that there are no hydration warnings with React 19 (and that behavior is unchanged with React 18).
<img width="332" height="257" alt="image" src="https://github.com/user-attachments/assets/bfa744db-c966-478e-9fb3-f4210f13024a" />

---